### PR TITLE
Update README.md

### DIFF
--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -42,6 +42,7 @@ Such behavior will be fixed in the upcoming versions.
 2. LVE statistics works only with SQLite, other databases (MySQL, postgreSQL) will be available in the next releases.
 3. `alt-php*-zts` are not available yet.
 4. The `tmpreaper package` is using instead of `tmpwatch`.
+5. PNG format for LVE Charts is not functional (lvechart utility may produce broken images)
 
 
 


### PR DESCRIPTION
added note that PNG format for LVE Charts is not functional on Ubuntu (lvechart utility may produce broken images)